### PR TITLE
Fixed setting menus crash in Android N

### DIFF
--- a/app/src/main/java/org/xdty/callerinfo/activity/SettingsActivity.java
+++ b/app/src/main/java/org/xdty/callerinfo/activity/SettingsActivity.java
@@ -32,6 +32,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.WindowManager;
+import android.widget.AbsListView;
 import android.widget.EditText;
 import android.widget.FrameLayout;
 import android.widget.LinearLayout;
@@ -278,7 +279,7 @@ public class SettingsActivity extends AppCompatActivity {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N
                     || Build.VERSION.RELEASE.equals("7.0") || Build.VERSION.RELEASE.equals("N")) {
                 ListView listView = (ListView) dialog.findViewById(android.R.id.list);
-                FrameLayout root = (FrameLayout) listView.getParent();
+                LinearLayout root = (LinearLayout) listView.getParent();
 
                 appBarLayout = (AppBarLayout) LayoutInflater.from(getActivity()).inflate(
                         R.layout.settings_toolbar, root, false);


### PR DESCRIPTION
Fixed inappropriate layout causes setting menus crash in Android N.
This patch request will fix the problem，Which in line 281.
Now it's OK for Android N phones to config the plugin settings and display the contents after click "more" button rather than crash.
Test passed in LG G6. Android 7.0.1.